### PR TITLE
Fix indentation in docker-compose example

### DIFF
--- a/docs/setup/docker-compose.md
+++ b/docs/setup/docker-compose.md
@@ -34,9 +34,9 @@ The simpliest docker compose setup for {{ extra.project }} is following:
     redis:
       image: redis:6
   volumes:
-      data:
-      index_db:
-      media:
+    data:
+    index_db:
+    media:
 ```
 
 You can access {{ extra.project }} user interface using any modern web browser (e.g. Firefox, Chrome).


### PR DESCRIPTION
The last line changed automatically when I changed the file in the github web ui. I guess there was a trailing new line missing.